### PR TITLE
chore: release v1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.0](https://github.com/unrs/rspack-resolver/compare/unrspack-resolver-v1.0.0...unrspack-resolver-v1.1.0) - 2025-03-15
+
+### Added
+
+- support resolving path with extra query ([#7](https://github.com/unrs/rspack-resolver/pull/7))
+
 ## [1.0.0](https://github.com/unrs/rspack-resolver/releases/tag/unrspack-resolver-v1.0.0) - 2025-03-15
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1080,7 +1080,7 @@ checksum = "d4c87d22b6e3f4a18d4d40ef354e97c90fcb14dd91d7dc0aa9d8a1172ebf7202"
 
 [[package]]
 name = "unrspack-resolver"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "cfg-if",
  "criterion2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members  = ["napi"]
 resolver = "2"
 
 [package]
-version      = "1.0.0"
+version      = "1.1.0"
 name         = "unrspack-resolver"
 authors      = ["UnRS"]
 categories   = ["development-tools"]

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rspack-resolver",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Oxc Resolver Node API with PNP support",
   "main": "index.js",
   "browser": "browser.js",


### PR DESCRIPTION



## 🤖 New release

* `unrspack-resolver`: 1.0.0 -> 1.1.0

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [1.1.0](https://github.com/unrs/rspack-resolver/compare/unrspack-resolver-v1.0.0...unrspack-resolver-v1.1.0) - 2025-03-15

### Added

- support resolving path with extra query ([#7](https://github.com/unrs/rspack-resolver/pull/7))

### Other

- let's release to npm
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).