### PR TITLE
chore: release v1.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.2](https://github.com/unrs/rspack-resolver/compare/unrspack-resolver-v1.1.1...unrspack-resolver-v1.1.2) - 2025-03-16
+
+### Fixed
+
+- references should take higher priority ([#13](https://github.com/unrs/rspack-resolver/pull/13))
+- takes paths and references into account at the same time
+- should always try resolve_path_alias
+
+### Other
+
+- add the failing case
+
 ## [1.1.1](https://github.com/unrs/rspack-resolver/compare/unrspack-resolver-v1.1.0...unrspack-resolver-v1.1.1) - 2025-03-16
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1080,7 +1080,7 @@ checksum = "d4c87d22b6e3f4a18d4d40ef354e97c90fcb14dd91d7dc0aa9d8a1172ebf7202"
 
 [[package]]
 name = "unrspack-resolver"
-version = "1.1.1"
+version = "1.1.2"
 dependencies = [
  "cfg-if",
  "criterion2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members  = ["napi"]
 resolver = "2"
 
 [package]
-version      = "1.1.1"
+version      = "1.1.2"
 name         = "unrspack-resolver"
 authors      = ["UnRS"]
 categories   = ["development-tools"]


### PR DESCRIPTION



## 🤖 New release

* `unrspack-resolver`: 1.1.1 -> 1.1.2

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [1.1.2](https://github.com/unrs/rspack-resolver/compare/unrspack-resolver-v1.1.1...unrspack-resolver-v1.1.2) - 2025-03-16

### Fixed

- references should take higher priority ([#13](https://github.com/unrs/rspack-resolver/pull/13))
- takes paths and references into account at the same time
- should always try resolve_path_alias

### Other

- add the failing case
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).