### PR TITLE
chore: release v1.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.2.2](https://github.com/unrs/rspack-resolver/compare/unrspack-resolver-v1.2.1...unrspack-resolver-v1.2.2) - 2025-03-19
+
+### <!-- 1 -->Bug Fixes
+
+- *(pnp)* support `pnpapi` core module and package deep link ([#24](https://github.com/unrs/rspack-resolver/pull/24))
+
 ## [1.2.0](https://github.com/unrs/rspack-resolver/compare/unrspack-resolver-v1.1.2...unrspack-resolver-v2.0.0) - 2025-03-18
 
 ### Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1181,7 +1181,7 @@ checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
 
 [[package]]
 name = "unrspack-resolver"
-version = "1.2.1"
+version = "1.2.2"
 dependencies = [
  "cfg-if",
  "criterion2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "2"
 
 [package]
 name = "unrspack-resolver"
-version = "1.2.1"
+version = "1.2.2"
 authors = ["UnRS"]
 categories = ["development-tools"]
 edition = "2024"

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rspack-resolver",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "Oxc Resolver Node API with PNP support",
   "main": "index.js",
   "browser": "browser.js",


### PR DESCRIPTION



## 🤖 New release

* `unrspack-resolver`: 1.2.1 -> 1.2.2 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [1.2.2](https://github.com/unrs/rspack-resolver/compare/unrspack-resolver-v1.2.1...unrspack-resolver-v1.2.2) - 2025-03-19

### <!-- 1 -->Bug Fixes

- *(pnp)* support `pnpapi` core module and package deep link ([#24](https://github.com/unrs/rspack-resolver/pull/24))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).